### PR TITLE
Adds support for Webpack 5.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,10 +11,10 @@ export function WebpackPnpExternals(options={}) {
         pnpApi = null;
     }
     return function() {
-        let [{ context, request }, callback] = arguments;
-        // support Webpack <= 4
-        if (arguments.length === 3) {
-            [context, request, callback] = arguments;
+        let [context, request, callback] = arguments;
+        // support Webpack 5
+        if (arguments.length === 2) {
+            [{ context, request }, callback] = arguments;
         }
         if(pnpApi == null)
             return callback();

--- a/src/index.js
+++ b/src/index.js
@@ -11,17 +11,10 @@ export function WebpackPnpExternals(options={}) {
         pnpApi = null;
     }
     return function() {
-        const arg1 = arguments[0];
-        const arg2 = arguments[1];
-        const arg3 = arguments[2];
-        let context = arg1;
-        let request = arg2;
-        let callback = arg3;
-        // in case of webpack 5
-        if (arg1 && arg1.context && arg1.request) {
-            context = arg1.context;
-            request = arg1.request;
-            callback = arg2;
+        let [{ context, request }, callback] = arguments;
+        // support Webpack <= 4
+        if (arguments.length === 3) {
+            [context, request, callback] = arguments;
         }
         if(pnpApi == null)
             return callback();

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,19 @@ export function WebpackPnpExternals(options={}) {
             throw err;
         pnpApi = null;
     }
-    return (context, request, callback) => {
+    return function() {
+        const arg1 = arguments[0];
+        const arg2 = arguments[1];
+        const arg3 = arguments[2];
+        let context = arg1;
+        let request = arg2;
+        let callback = arg3;
+        // in case of webpack 5
+        if (arg1 && arg1.context && arg1.request) {
+            context = arg1.context;
+            request = arg1.request;
+            callback = arg2;
+        }
         if(pnpApi == null)
             return callback();
         //don't check relative or absolute requires


### PR DESCRIPTION
Thanks for creating this package!

When using this package with Webpack 5, a warning is logged:
```
(node:6153) [DEP_WEBPACK_EXTERNALS_FUNCTION_PARAMETERS] DeprecationWarning: The externals-function should be defined like ({context, request}, cb) => { ... }
(Use `node --trace-deprecation ...` to show where the warning was created)
```

According to the [Webpack 5 Release Guide](https://webpack.js.org/blog/2020-10-10-webpack-5-release/), the `externals` signature has changed:
> externals when passing a function, it has now a different signature ({ context, request }, callback)

This PR implements the specific changes necessary to support Webpack 5, while also providing backwards compatibility with Webpack < 5. This was ripped straight from `webpack-node-externals`, as they have already addressed this.